### PR TITLE
Enable running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM pytorch/pytorch
+
+RUN apt-get update
+RUN apt-get install -y build-essential cmake
+RUN apt-get install -y libopenblas-dev liblapack-dev
+RUN apt-get install -y libx11-dev libgtk-3-dev
+COPY requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -f Dockerfile -t "realtime-emotion-monitor" .
+
+shell: build
+	docker run -it -e DISPLAY=unix$(DISPLAY) -v /tmp/.X11-unix:/tmp/.X11-unix --device /dev/video0 -v $(shell pwd)/:/workspace "realtime-emotion-monitor" bash

--- a/liveVideoFrameRead.py
+++ b/liveVideoFrameRead.py
@@ -42,15 +42,15 @@ args = vars(ap.parse_args())
 print(os.getcwd())
 
 # Set path to your project directory
-path = '/Users/szhong/Documents/GitHub/EmotionMonitor/'
+path = '/workspace'
 
 # Set up directories
 model_dir = 'src/model/'
-classifier_dir = path + model_dir + "haarcascade_frontalface_default.xml"
-learner_dir = path + model_dir
-shape_predictor_dir = path + model_dir + "shape_predictor_68_face_landmarks.dat"
+classifier_dir = os.path.join(path, model_dir, "haarcascade_frontalface_default.xml")
+learner_dir = os.path.join(path, model_dir)
+shape_predictor_dir = os.path.join(path, model_dir, "shape_predictor_68_face_landmarks.dat")
 
-sound_dir = path + 'src/sound/sound1.mp3'
+sound_dir = os.path.join(path, 'src/sound/sound1.mp3')
 SOUND_TIME_INTERVAL = 20  # in seconds
 
 learn = load_learner(path=learner_dir, file='export.pkl')


### PR DESCRIPTION
This PR enables building and running the emotion tracker in Docker.

It is an initial attempt and a couple of changes which should be added:
1. See if there is a way to get the webcam working on Mac
2. See what is required to get the Xserver connection happening on mac
3. Use GPU PyTorch base image